### PR TITLE
Fix missing images on about us page

### DIFF
--- a/about-us/index.html
+++ b/about-us/index.html
@@ -100,8 +100,8 @@
 							<div class="col-md-4">
 								<div class="c-content-events-1-item " >
 									<div class="c-content-events-1-img-container">
-										<img class="c-content-events-1-img" src="/assets/base/img/content/stock5/72.jpg"
-											style="height: 270px; object-fit: cover;" />
+                                                                                <img class="c-content-events-1-img" src="/assets/base/img/content/team/team5.jpg"
+                                                                                        style="height: 270px; object-fit: cover;" />
 									</div>
 									<div class="c-content-events-1-content-container">
 										<h3 class="c-content-events-1-title">We excel...</h3>
@@ -114,8 +114,8 @@
 							<div class="col-md-4">
 								<div class="c-content-events-1-item ">
 									<div class="c-content-events-1-img-container">
-										<img class="c-content-events-1-img" src="/assets/base/img/content/stock3/40.jpg"
-											style="height: 270px; object-fit: cover;" />
+                                                                                <img class="c-content-events-1-img" src="/assets/base/img/content/team/team3.jpg"
+                                                                                        style="height: 270px; object-fit: cover;" />
 									</div>
 									<div class="c-content-events-1-content-container">
 										<h3 class="c-content-events-1-title">We innovate...</h3>
@@ -127,9 +127,9 @@
 							<div class="col-md-4">
 								<div class="c-content-events-1-item ">
 									<div class="c-content-events-1-img-container">
-										<img class="c-content-events-1-img"
-											src="/assets/base/img/content/stock/au-1.jpg"
-											style="height: 270px; object-fit: cover;" />
+                                                                                <img class="c-content-events-1-img"
+                                                                                        src="/assets/base/img/content/team/team9.jpg"
+                                                                                        style="height: 270px; object-fit: cover;" />
 									</div>
 									<div class="c-content-events-1-content-container">
 										<h3 class="c-content-events-1-title">We accomplish...</h3>
@@ -238,8 +238,8 @@
 						</div>
 					</div>
 				</div>
-				<img class="col-md-6 col-xs-12 " 
-					style="border-radius: 5%; object-fit: cover;" src="../assets/base/img/content/stock3/5.jpg"></img>
+                                <img class="col-md-6 col-xs-12 "
+                                        style="border-radius: 5%; object-fit: cover;" src="/assets/base/img/content/team/team11.jpg"></img>
 			</div>
 		</div>
 		<!-- END: MISSION -->
@@ -249,8 +249,8 @@
 		<!-- BEGIN: VISION -->
 		<div class="container c-size-sm">
 			<div class="row">
-				<img class="col-md-6 col-xs-12 " 
-					style="border-radius: 5%; object-fit: cover;" src="../assets/base/img/content/stock3/6.jpg"></img>
+                                <img class="col-md-6 col-xs-12 "
+                                        style="border-radius: 5%; object-fit: cover;" src="/assets/base/img/content/team/team12.jpg"></img>
 				<div class="col-md-6 col-xs-12">
 					<div class="c-feature-15-container c-bg-white ">
 						<h2 class="c-feature-15-title "


### PR DESCRIPTION
## Summary
- replace outdated stock image references on the About Us page with existing team photography assets
- update mission and vision sections to use available imagery from the repository to avoid broken links

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cad370139083208edd978e0df5cf8b